### PR TITLE
Fix current unit test to match #19

### DIFF
--- a/processes/processes.go
+++ b/processes/processes.go
@@ -314,7 +314,7 @@ func setProcMetrics(instances []Proc) map[string]uint64 {
 }
 
 func fillNsElement(element *core.NamespaceElement, value string) core.NamespaceElement {
-	return core.NamespaceElement{value, element.Description, element.Name}
+	return core.NamespaceElement{Value: value, Description: element.Description, Name: element.Name}
 }
 
 // procPlugin holds host name and reference to metricCollector which has method of GetStats()

--- a/processes/procstat_test.go
+++ b/processes/procstat_test.go
@@ -1,4 +1,4 @@
-// +build small
+// +build unit
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -122,8 +122,8 @@ func TestGetStats(t *testing.T) {
 			os.Remove(fileToRemove)
 			results, err := dut.GetStats(mockPath)
 
-			So(err, ShouldNotBeNil)
-			So(results, ShouldBeEmpty)
+			So(err, ShouldBeNil)
+			So(results, ShouldNotBeEmpty)
 		}
 	})
 


### PR DESCRIPTION
We accidentally disabled a unit test. This updates the test to match the
behavior change from #19 where we no longer raising errors when proc
stat files no longer exist on the sytem.