### PR TITLE
Reworked CollectMetrics, fixes #22

### DIFF
--- a/processes/processes_test.go
+++ b/processes/processes_test.go
@@ -38,10 +38,14 @@ import (
 const (
 	mockProcName = "NetworkManager"
 	mockProcPid  = 815
+
+	mockProcName2 = "fake"
+	mockProcPid2  = 315
 )
 
 var (
-	mockProc = makeMockProc(mockProcName, mockProcPid)
+	mockProc  = makeMockProc(mockProcName, mockProcPid)
+	mockProc2 = makeMockProc(mockProcName, mockProcPid)
 )
 
 type mcMock struct {
@@ -145,7 +149,15 @@ func TestCollectMetrics(t *testing.T) {
 				Namespace_: core.NewNamespace("intel", "procfs", "processes", "zombie"),
 				Config_:    cfg.ConfigDataNode,
 			},
+
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "procfs", "processes").
+					AddDynamicElement("process_name", "process name").
+					AddStaticElement("ps_count"),
+			},
 		}
+
+		mockMts[len(mockMts)-1].Namespace_[3].Value = "fake"
 
 		Convey("new processes collector", func() {
 			So(procPlugin, ShouldNotBeNil)
@@ -169,6 +181,7 @@ func TestCollectMetrics(t *testing.T) {
 
 			mc.On("GetStats").Return(map[string][]Proc{
 				"NetworkManager": []Proc{mockProc},
+				"fake":           []Proc{mockProc2},
 			}, nil)
 
 			Convey("when names of collect metrics are valid", func() {
@@ -190,8 +203,8 @@ func TestCollectMetrics(t *testing.T) {
 				})
 
 				So(err, ShouldBeNil)
-				// 1 metric exposed by process
-				So(len(results), ShouldEqual, 1)
+				// 2 metrics exposed by processes
+				So(len(results), ShouldEqual, 2)
 
 				for _, r := range results {
 					ns := r.Namespace()
@@ -209,8 +222,8 @@ func TestCollectMetrics(t *testing.T) {
 				results, err := procPlugin.CollectMetrics(mockMtsWithAsterisk)
 
 				So(err, ShouldBeNil)
-				// 14 dynamic metrics exposed by process + 10 status metrics defined in mockMts
-				So(len(results), ShouldEqual, 11)
+				// 2 dynamic metrics exposed by processes + 10 status metrics defined in mockMts
+				So(len(results), ShouldEqual, 12)
 			})
 
 			Convey("when name of collect metric is invalid", func() {
@@ -222,7 +235,7 @@ func TestCollectMetrics(t *testing.T) {
 				})
 
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "Unknown namespace length")
+				So(err.Error(), ShouldContainSubstring, "Unknown namespace")
 				So(results, ShouldBeEmpty)
 			})
 


### PR DESCRIPTION
Fixes #22

Summary of changes:
- CollectMetrics now correctly recognizes wildcard and specific instance for dynamic metrics
- Result metrics are no longer duplicated
- Minor optimizations when referring for given stat name
- Updated unit tests

How to verify it:
- Create task with specific instance given for process name and check if it's present in results, and no other processes are present

Testing done:
- Unit tests
- Manual testing
