### PR TITLE
Add PID namespace entry

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -5,27 +5,41 @@ This plugin has the ability to gather the following metrics:
 
 Namespace | Data Type | Description
 ----------|-----------|-----------------------
-/intel/procfs/processes/running | uint64 | Number of processes in state running
-/intel/procfs/processes/sleeping | uint64 | Number of processes in state sleeping
-/intel/procfs/processes/waiting | uint64 | Number of processes in state waiting
-/intel/procfs/processes/zombie | uint64 | Number of processes in state zombie
-/intel/procfs/processes/stopped | uint64 | Number of processes in state stopped
-/intel/procfs/processes/tracing | uint64 | Number of processes in state tracing
-/intel/procfs/processes/dead | uint64 | Number of processes in state dead
-/intel/procfs/processes/wakekill | uint64 | Number of processes in state wakekill
-/intel/procfs/processes/waking | uint64 | Number of processes in state waking
-/intel/procfs/processes/parked | uint64 | Number of processes in state parked
-/intel/procfs/processes/\<process_name\>/ps_vm | uint64 | Virtual memory size in bytes 
-/intel/procfs/processes/\<process_name\>/ps_rss | uint64 | Resident Set Size: number of pages the process has in real memory
-/intel/procfs/processes/\<process_name\>/ps_data | uint64 | Size of data segments
-/intel/procfs/processes/\<process_name\>/ps_code | uint64 | Size of text segments
-/intel/procfs/processes/\<process_name\>/ps_stacksize | uint64 | Stack size
-/intel/procfs/processes/\<process_name\>/ps_cputime_user | uint64 | Amount of time that this process has been scheduled in user mode
-/intel/procfs/processes/\<process_name\>/ps_cputime_system | uint64 | Amount of time that this process has been scheduled in kernel mode
-/intel/procfs/processes/\<process_name\>/ps_pagefaults_min | uint64 | The number of minor faults the process has made
-/intel/procfs/processes/\<process_name\>/ps_pagefaults_maj | uint64 | The number of major faults the process has made
-/intel/procfs/processes/\<process_name\>/ps_disk_ops_syscr | uint64 | Attempt to count the number of read I/O operations
-/intel/procfs/processes/\<process_name\>/ps_disk_ops_syscw | uint64 | Attempt to count the number of write I/O operations
-/intel/procfs/processes/\<process_name\>/ps_disk_octets_rchar | uint64 | The number of bytes which this task has caused to be read from storage
-/intel/procfs/processes/\<process_name\>/ps_disk_octets_wchar | uint64 | The number of bytes which this task has caused, or shall cause to be written to disk
-/intel/procfs/processes/\<process_name\>/ps_count | uint64 | Number of process instances
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_cmdline | string | Process command line with arguments
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_code | uint64 | Size of text segment (bytes)
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_cputime_system | uint64 | Amount of time that this process has been scheduled in kernel mode (in jiff)
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_cputime_user | uint64 | Amount of time that this process has been scheduled in user mode (in jiff)
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_data | uint64 | Size of data segments (in bytes)
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_octets_rchar | uint64 | The number of bytes which this task has caused to be read from storage (in bytes)
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_octets_wchar | uint64 | The number of bytes which this task has caused, or shall cause to be written to disk (in bytes)
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_ops_syscr | uint64 | Attempt to count the number of read I/O operations
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_ops_syscw | uint64 | Attempt to count the number of write I/O operations
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_pagefaults_maj | uint64 | The number of major faults the process has made
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_pagefaults_min | uint64 | The number of minor faults the process has made
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_rss | uint64 | Resident Set Size: number of pages the process has in real memory
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_stacksize | uint64 | Stack size (in bytes)
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_vm | uint64 | Virtual memory size in bytes (in bytes)
+/intel/procfs/processes/process/[process_name]/all/ps_code | uint64 | Size of text segment (in bytes)
+/intel/procfs/processes/process/[process_name]/all/ps_cputime_system | uint64 | Amount of time that this process has been scheduled in kernel mode (in jiff)
+/intel/procfs/processes/process/[process_name]/all/ps_cputime_user | uint64 | Amount of time that this process has been scheduled in user mode (in jiff)
+/intel/procfs/processes/process/[process_name]/all/ps_data | uint64 | Size of data segments (in bytes)
+/intel/procfs/processes/process/[process_name]/all/ps_disk_octets_rchar | uint64 | The number of bytes which this task has caused to be read from storage (in bytes)
+/intel/procfs/processes/process/[process_name]/all/ps_disk_octets_wchar | uint64 | The number of bytes which this task has caused, or shall cause to be written to disk (in bytes)
+/intel/procfs/processes/process/[process_name]/all/ps_disk_ops_syscr | uint64 | Attempt to count the number of read I/O operations
+/intel/procfs/processes/process/[process_name]/all/ps_disk_ops_syscw | uint64 | Attempt to count the number of write I/O operations
+/intel/procfs/processes/process/[process_name]/all/ps_pagefaults_maj | uint64 | The number of major faults the process has made
+/intel/procfs/processes/process/[process_name]/all/ps_pagefaults_min | uint64 | The number of minor faults the process has made
+/intel/procfs/processes/process/[process_name]/all/ps_rss | uint64 | Resident Set Size: number of pages the process has in real memory
+/intel/procfs/processes/process/[process_name]/all/ps_stacksize | uint64 | Stack size (in bytes)
+/intel/procfs/processes/process/[process_name]/all/ps_vm | uint64 | Virtual memory size (in bytes)
+/intel/procfs/processes/process/[process_name]/ps_count | uint64 | Number of process instances
+/intel/procfs/processes/state/dead | uint64 | Number of processes with 'dead' status
+/intel/procfs/processes/state/parked | uint64 | Number of processes with 'parked' status
+/intel/procfs/processes/state/running | uint64 | Number of processes with 'running' status
+/intel/procfs/processes/state/sleeping | uint64 | Number of processes with 'sleeping' status
+/intel/procfs/processes/state/stopped | uint64 | Number of processes with 'stopped' status
+/intel/procfs/processes/state/tracing | uint64 | Number of processes with 'tracing' status
+/intel/procfs/processes/state/waiting | uint64 | Number of processes with 'waiting' status
+/intel/procfs/processes/state/wakekill | uint64 | Number of processes with 'wakekill' status
+/intel/procfs/processes/state/waking | uint64 | Number of processes with 'waking' status
+/intel/procfs/processes/state/zombie | uint64 | Number of processes with 'zombie' status

--- a/README.md
+++ b/README.md
@@ -71,32 +71,47 @@ $ snaptel plugin load snap-plugin-publisher-file
 ```
 See available metrics for your system:
 ```
-$ snaptel metric list
-NAMESPACE                                              VERSIONS
-/intel/procfs/processes/running                        7
-/intel/procfs/processes/sleeping                       7
-/intel/procfs/processes/waiting                        7
-/intel/procfs/processes/zombie                         7
-/intel/procfs/processes/stopped                        7
-/intel/procfs/processes/tracing                        7
-/intel/procfs/processes/dead                           7
-/intel/procfs/processes/wakekill                       7
-/intel/procfs/processes/waking                         7
-/intel/procfs/processes/parked                         7
-/intel/procfs/processes/*/ps_vm                        7
-/intel/procfs/processes/*/ps_rss                       7
-/intel/procfs/processes/*/ps_data                      7
-/intel/procfs/processes/*/ps_code                      7
-/intel/procfs/processes/*/ps_stacksize                 7
-/intel/procfs/processes/*/ps_cputime_user              7
-/intel/procfs/processes/*/ps_cputime_system            7
-/intel/procfs/processes/*/ps_pagefaults_min            7
-/intel/procfs/processes/*/ps_pagefaults_maj            7
-/intel/procfs/processes/*/ps_disk_ops_syscr            7
-/intel/procfs/processes/*/ps_disk_ops_syscw            7
-/intel/procfs/processes/*/ps_disk_octets_rchar         7
-/intel/procfs/processes/*/ps_disk_octets_wchar         7
-/intel/procfs/processes/*/ps_count                     7
+$ snaptel metric list --verbose 
+NAMESPACE                                                                            VERSION    UNIT    DESCRIPTION
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_cmdline              8                  Process command line with arguments
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_code                 8          B       Size of text segment
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_cputime_system       8          Jiff    Amount of time that this process has been scheduled in kernel mode
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_cputime_user         8          Jiff    Amount of time that this process has been scheduled in user mode
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_data                 8          B       Size of data segments
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_octets_rchar    8          B       The number of bytes which this task has caused to be read from storage
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_octets_wchar    8          B       The number of bytes which this task has caused, or shall cause to be written to disk
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_ops_syscr       8                  Attempt to count the number of read I/O operations
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_disk_ops_syscw       8                  Attempt to count the number of write I/O operations
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_pagefaults_maj       8                  The number of major faults the process has made
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_pagefaults_min       8                  The number of minor faults the process has made
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_rss                  8                  Resident Set Size: number of pages the process has in real memory
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_stacksize            8          B       Stack size
+/intel/procfs/processes/process/[process_name]/[process_pid]/ps_vm                   8          B       Virtual memory size in bytes
+/intel/procfs/processes/process/[process_name]/all/ps_code                           8          B       Size of text segment
+/intel/procfs/processes/process/[process_name]/all/ps_cputime_system                 8          Jiff    Amount of time that this process has been scheduled in kernel mode
+/intel/procfs/processes/process/[process_name]/all/ps_cputime_user                   8          Jiff    Amount of time that this process has been scheduled in user mode
+/intel/procfs/processes/process/[process_name]/all/ps_data                           8          B       Size of data segments
+/intel/procfs/processes/process/[process_name]/all/ps_disk_octets_rchar              8          B       The number of bytes which this task has caused to be read from storage
+/intel/procfs/processes/process/[process_name]/all/ps_disk_octets_wchar              8          B       The number of bytes which this task has caused, or shall cause to be written to disk
+/intel/procfs/processes/process/[process_name]/all/ps_disk_ops_syscr                 8                  Attempt to count the number of read I/O operations
+/intel/procfs/processes/process/[process_name]/all/ps_disk_ops_syscw                 8                  Attempt to count the number of write I/O operations
+/intel/procfs/processes/process/[process_name]/all/ps_pagefaults_maj                 8                  The number of major faults the process has made
+/intel/procfs/processes/process/[process_name]/all/ps_pagefaults_min                 8                  The number of minor faults the process has made
+/intel/procfs/processes/process/[process_name]/all/ps_rss                            8                  Resident Set Size: number of pages the process has in real memory
+/intel/procfs/processes/process/[process_name]/all/ps_stacksize                      8          B       Stack size
+/intel/procfs/processes/process/[process_name]/all/ps_vm                             8          B       Virtual memory size in bytes
+/intel/procfs/processes/process/[process_name]/ps_count                              8                  Number of process instances
+/intel/procfs/processes/state/dead                                                   8                  Number of processes with 'dead' status
+/intel/procfs/processes/state/parked                                                 8                  Number of processes with 'parked' status
+/intel/procfs/processes/state/running                                                8                  Number of processes with 'running' status
+/intel/procfs/processes/state/sleeping                                               8                  Number of processes with 'sleeping' status
+/intel/procfs/processes/state/stopped                                                8                  Number of processes with 'stopped' status
+/intel/procfs/processes/state/tracing                                                8                  Number of processes with 'tracing' status
+/intel/procfs/processes/state/waiting                                                8                  Number of processes with 'waiting' status
+/intel/procfs/processes/state/wakekill                                               8                  Number of processes with 'wakekill' status
+/intel/procfs/processes/state/waking                                                 8                  Number of processes with 'waking' status
+/intel/procfs/processes/state/zombie                                                 8                  Number of processes with 'zombie' status
+
 ```
 
 

--- a/examples/tasks/processes-file.json
+++ b/examples/tasks/processes-file.json
@@ -7,11 +7,11 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/intel/procfs/processes/*/ps_disk_ops_syscr": {},
-                "/intel/procfs/processes/*/ps_disk_ops_syscw": {},
-                "/intel/procfs/processes/running": {},
-                "/intel/procfs/processes/stopped": {},
-                "/intel/procfs/processes/waiting": {}
+                "/intel/procfs/processes/process/*/*/ps_disk_ops_syscr": {},
+                "/intel/procfs/processes/process/*/*/ps_disk_ops_syscw": {},
+                "/intel/procfs/processes/state/running": {},
+                "/intel/procfs/processes/state/stopped": {},
+                "/intel/procfs/processes/state/waiting": {}
             },
             "publish": [
                 {
@@ -21,7 +21,6 @@
                     }
                 }
             ],
-
             "config": null
         }
     }

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,80 @@
+hash: d46605f72d13e7b883baac5b1b7d5639f8fb7fd75c8d8b63e0ff7215c8927c7e
+updated: 2017-05-29T16:14:51.787863802+02:00
+imports:
+- name: github.com/golang/protobuf
+  version: 888eb0692c857ec880338addf316bd662d5e630e
+  subpackages:
+  - proto
+- name: github.com/intelsdi-x/snap-plugin-lib-go
+  version: d1d32a057c0c23169796016876ce89634b2c012f
+  subpackages:
+  - v1
+  - v1/plugin
+  - v1/plugin/rpc
+- name: github.com/intelsdi-x/snap-plugin-utilities
+  version: 3c37e3965f3fc2f24714779d3bae7ba7032b87a9
+  subpackages:
+  - str
+- name: github.com/julienschmidt/httprouter
+  version: 975b5c4c7c21c0e3d2764200bf2aa8e34657ae6e
+- name: github.com/Sirupsen/logrus
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: github.com/urfave/cli
+  version: d70f47eeca3afd795160003bc6e28b001d60c67c
+- name: golang.org/x/net
+  version: 154d9f9ea81208afed560f4cf27b4860c8ed1904
+  subpackages:
+  - context
+  - http2
+  - http2/hpack
+  - internal/timeseries
+  - lex/httplex
+  - trace
+- name: golang.org/x/sys
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  subpackages:
+  - unix
+- name: google.golang.org/grpc
+  version: 0032a855ba5c8a3c8e0d71c2deef354b70af1584
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  subpackages:
+  - spew
+- name: github.com/gopherjs/gopherjs
+  version: 4b53e1bddba0e2f734514aeb6c02db652f4c6fe8
+  subpackages:
+  - js
+- name: github.com/jtolds/gls
+  version: 8ddce2a84170772b95dd5d576c48d517b22cac63
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/smartystreets/assertions
+  version: 443d812296a84445c202c085f19e18fc238f8250
+  subpackages:
+  - internal/go-render/render
+  - internal/oglematchers
+- name: github.com/smartystreets/goconvey
+  version: 995f5b2e021c69b8b028ba6d0b05c1dd500783db
+  subpackages:
+  - convey
+  - convey/gotest
+  - convey/reporting
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
+- name: github.com/stretchr/testify
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  subpackages:
+  - assert
+  - mock

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,11 @@
 package: github.com/intelsdi-x/snap-plugin-collector-processes
 import:
-- package: github.com/intelsdi-x/snap
-  version: ^1.0.0
-- package: github.com/intelsdi-x/snap-plugin-utilities
-  version: 3c37e3965f3fc2f24714779d3bae7ba7032b87a9
+import:
+- package: github.com/intelsdi-x/snap-plugin-lib-go
+  subpackages:
+  - v1
+testImport:
+- package: github.com/smartystreets/goconvey
+  subpackages:
+  - convey
+

--- a/main.go
+++ b/main.go
@@ -20,10 +20,8 @@ limitations under the License.
 package main
 
 import (
-	"os"
-
 	"github.com/intelsdi-x/snap-plugin-collector-processes/processes"
-	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 )
 
 func main() {
@@ -31,10 +29,5 @@ func main() {
 	if procPlg == nil {
 		panic("Failed to initialize plugin\n")
 	}
-
-	plugin.Start(
-		processes.Meta(),
-		procPlg,
-		os.Args[1],
-	)
+	plugin.StartCollector(procPlg, processes.PluginName, processes.PluginVersion, processes.Meta()...)
 }

--- a/processes/processes_test.go
+++ b/processes/processes_test.go
@@ -25,12 +25,10 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
-	"github.com/intelsdi-x/snap/control/plugin"
-	"github.com/intelsdi-x/snap/core"
-
-	"github.com/intelsdi-x/snap/core/ctypes"
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/mock"
 )
@@ -41,22 +39,26 @@ const (
 
 	mockProcName2 = "fake"
 	mockProcPid2  = 315
+
+	mockProcName3 = "fake"
+	mockProcPid3  = 316
 )
 
 var (
 	mockProc  = makeMockProc(mockProcName, mockProcPid)
-	mockProc2 = makeMockProc(mockProcName, mockProcPid)
+	mockProc2 = makeMockProc(mockProcName2, mockProcPid2)
+	mockProc3 = makeMockProc(mockProcName3, mockProcPid3)
 )
 
 type mcMock struct {
 	mock.Mock
 }
 
-func (mc *mcMock) GetStats(procPath string) (map[string][]Proc, error) {
+func (mc *mcMock) GetStats(procPath string) (map[string]map[int]Proc, error) {
 	args := mc.Called()
-	var r0 map[string][]Proc
+	var r0 map[string]map[int]Proc
 	if args.Get(0) != nil {
-		r0 = args.Get(0).(map[string][]Proc)
+		r0 = args.Get(0).(map[string]map[int]Proc)
 	}
 	return r0, args.Error(1)
 }
@@ -78,7 +80,7 @@ func TestGetConfigPolicy(t *testing.T) {
 
 func TestGetMetricTypes(t *testing.T) {
 
-	var cfg plugin.ConfigType
+	var cfg plugin.Config
 
 	Convey("get metric types successfully", t, func() {
 		procPlugin := New()
@@ -92,10 +94,11 @@ func TestGetMetricTypes(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(results, ShouldNotBeEmpty)
 
-		So(len(results), ShouldEqual, States.Size()+len(metricNames))
+		// plugin returns total of 38 metrics available, see the README.md
+		So(len(results), ShouldEqual, 38)
 
 		for _, res := range results {
-			So(res.Description(), ShouldNotBeBlank)
+			So(res.Description, ShouldNotBeBlank)
 		}
 	})
 }
@@ -105,59 +108,61 @@ func TestCollectMetrics(t *testing.T) {
 	Convey("collect metric", t, func() {
 		procPlugin := New()
 
-		cfg := plugin.NewPluginConfigType()
-		cfg.AddItem("proc_path", ctypes.ConfigValueStr{"/proc"})
+		cfg := plugin.Config{
+			"proc_path": "/proc",
+		}
 
-		mockMts := []plugin.MetricType{
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "dead"),
-				Config_:    cfg.ConfigDataNode,
+		mockMts := []plugin.Metric{
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "dead"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "parked"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "parked"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "running"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "running"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "sleeping"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "sleeping"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "stopped"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "stopped"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "tracing"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "tracing"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "waiting"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "waiting"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "wakekill"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "wakekill"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "waking"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "waking"),
+				Config:    cfg,
 			},
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes", "zombie"),
-				Config_:    cfg.ConfigDataNode,
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "state", "zombie"),
+				Config:    cfg,
 			},
 
-			plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes").
-					AddDynamicElement("process_name", "process name").
-					AddStaticElement("ps_count"),
+			plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process").
+					AddDynamicElement("process_name", "name of the process").
+					AddDynamicElement("process_pid", "identifier of the process").
+					AddStaticElement("ps_data"),
 			},
 		}
 
-		mockMts[len(mockMts)-1].Namespace_[3].Value = "fake"
+		mockMts[len(mockMts)-1].Namespace[4].Value = "fake"
 
 		Convey("new processes collector", func() {
 			So(procPlugin, ShouldNotBeNil)
@@ -179,63 +184,177 @@ func TestCollectMetrics(t *testing.T) {
 			mc := &mcMock{}
 			procPlugin.mc = mc
 
-			mc.On("GetStats").Return(map[string][]Proc{
-				"NetworkManager": []Proc{mockProc},
-				"fake":           []Proc{mockProc2},
+			mc.On("GetStats").Return(map[string]map[int]Proc{
+				"NetworkManager": map[int]Proc{
+					mockProcPid: mockProc,
+				},
+				"fake": map[int]Proc{
+					mockProcPid2: mockProc2,
+					mockProcPid3: mockProc3,
+				},
 			}, nil)
 
 			Convey("when names of collect metrics are valid", func() {
 				results, err := procPlugin.CollectMetrics(mockMts)
 
 				So(err, ShouldBeNil)
-				So(len(results), ShouldEqual, len(mockMts))
+				// 12 metrics exposed - 11 metrics defined in mockMts, where last metric returns data for 2 PIDs
+				So(len(results), ShouldEqual, 12)
 			})
 
-			Convey("when name of collect metric is equal to asterisk (exposed dynamic metrics)", func() {
+			Convey("when name of collect metric process name and pid is equal to asterisk (exposed dynamic metrics)", func() {
 
-				results, err := procPlugin.CollectMetrics([]plugin.MetricType{
-					plugin.MetricType{
-						Namespace_: core.NewNamespace("intel", "procfs", "processes").
-							AddDynamicElement("process_name", "process name").
-							AddStaticElement("ps_count"),
-						Config_: cfg.ConfigDataNode,
+				results, err := procPlugin.CollectMetrics([]plugin.Metric{
+					plugin.Metric{
+						Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process").
+							AddDynamicElement("process_name", "name of the process").
+							AddDynamicElement("process_pid", "identifier of the process").
+							AddStaticElement("ps_data"),
+						Config: cfg,
 					},
 				})
 
 				So(err, ShouldBeNil)
-				// 2 metrics exposed by processes
-				So(len(results), ShouldEqual, 2)
+				// 3 metrics exposed by processes
+				So(len(results), ShouldEqual, 3)
 
 				for _, r := range results {
-					ns := r.Namespace()
-					So(mockProc.validateValue(ns[len(ns)-1].Value, r.Data().(uint64)), ShouldBeTrue)
+					ns := r.Namespace
+					So(mockProc.validateValue(ns[len(ns)-1].Value, r.Data.(uint64)), ShouldBeTrue)
 				}
 			})
 
+			Convey("when name of collect metric process name is equal to asterisk and pid specified", func() {
+
+				results, err := procPlugin.CollectMetrics([]plugin.Metric{
+					plugin.Metric{
+						Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process").
+							AddDynamicElement("process_name", "name of the process").
+							AddStaticElement(strconv.Itoa(mockProcPid)).
+							AddStaticElement("ps_data"),
+						Config: cfg,
+					},
+				})
+
+				So(err, ShouldBeNil)
+				// 1 metrics exposed by specific process pid
+				So(len(results), ShouldEqual, 1)
+
+				for _, r := range results {
+					ns := r.Namespace
+					So(mockProc.validateValue(ns[len(ns)-1].Value, r.Data.(uint64)), ShouldBeTrue)
+				}
+			})
+
+			Convey("when name of collect metric process name is specified and pid is equal to asterisk", func() {
+
+				results, err := procPlugin.CollectMetrics([]plugin.Metric{
+					plugin.Metric{
+						Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process").
+							AddStaticElement("fake").
+							AddDynamicElement("process_pid", "identifier of the process").
+							AddStaticElement("ps_data"),
+						Config: cfg,
+					},
+				})
+
+				So(err, ShouldBeNil)
+				// 2 metrics exposed by fake process with 2 pids
+				So(len(results), ShouldEqual, 2)
+
+				for _, r := range results {
+					ns := r.Namespace
+					So(mockProc.validateValue(ns[len(ns)-1].Value, r.Data.(uint64)), ShouldBeTrue)
+				}
+			})
+
+			Convey("check process instance count with process name specified", func() {
+				results, err := procPlugin.CollectMetrics([]plugin.Metric{
+					plugin.Metric{
+						Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process", "fake", "ps_count"),
+						Config:    cfg,
+					},
+					plugin.Metric{
+						Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process", "NetworkManager", "ps_count"),
+						Config:    cfg,
+					},
+				})
+
+				So(err, ShouldBeNil)
+				So(len(results), ShouldEqual, 2)
+
+				matchedNs := 0
+				for _, r := range results {
+					ns := strings.Join(r.Namespace.Strings(), "/")
+
+					switch ns {
+					case "intel/procfs/processes/process/fake/ps_count":
+						matchedNs++
+						So(r.Data, ShouldEqual, 2)
+					case "intel/procfs/processes/process/NetworkManager/ps_count":
+						matchedNs++
+						So(r.Data, ShouldEqual, 1)
+					}
+				}
+
+				So(matchedNs, ShouldEqual, 2)
+			})
+
+			Convey("check process instance count with process name equal to asterisk", func() {
+				results, err := procPlugin.CollectMetrics([]plugin.Metric{
+					plugin.Metric{
+						Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process").
+							AddDynamicElement("process_name", "name of the process").
+							AddStaticElement("ps_count"),
+						Config: cfg,
+					},
+				})
+
+				So(err, ShouldBeNil)
+				So(len(results), ShouldEqual, 2)
+
+				matchedNs := 0
+				for _, r := range results {
+					ns := strings.Join(r.Namespace.Strings(), "/")
+
+					switch ns {
+					case "intel/procfs/processes/process/fake/ps_count":
+						matchedNs++
+						So(r.Data, ShouldEqual, 2)
+					case "intel/procfs/processes/process/NetworkManager/ps_count":
+						matchedNs++
+						So(r.Data, ShouldEqual, 1)
+					}
+				}
+
+				So(matchedNs, ShouldEqual, 2)
+			})
+
 			Convey("when names of collect metrics include asterisk", func() {
-				mockMtsWithAsterisk := append(mockMts, plugin.MetricType{
-					Namespace_: core.NewNamespace("intel", "procfs", "processes").
-						AddDynamicElement("process_name", "process name").
-						AddStaticElement("ps_count"),
+				mockMtsWithAsterisk := append(mockMts, plugin.Metric{
+					Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process").
+						AddDynamicElement("process_name", "name of the process").
+						AddDynamicElement("process_pid", "identifier of the process").
+						AddStaticElement("ps_data"),
 				})
 
 				results, err := procPlugin.CollectMetrics(mockMtsWithAsterisk)
 
 				So(err, ShouldBeNil)
-				// 2 dynamic metrics exposed by processes + 10 status metrics defined in mockMts
-				So(len(results), ShouldEqual, 12)
+				// 5 dynamic metrics exposed by processes + 10 status metrics defined in mockMts
+				So(len(results), ShouldEqual, 15)
 			})
 
 			Convey("when name of collect metric is invalid", func() {
-				results, err := procPlugin.CollectMetrics([]plugin.MetricType{
-					plugin.MetricType{
-						Namespace_: core.NewNamespace("intel", "procfs", "zombie"),
-						Config_:    cfg.ConfigDataNode,
+				results, err := procPlugin.CollectMetrics([]plugin.Metric{
+					plugin.Metric{
+						Namespace: plugin.NewNamespace("intel", "procfs", "zombie"),
+						Config:    cfg,
 					},
 				})
 
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "Unknown namespace")
+				So(err.Error(), ShouldContainSubstring, "Bad namespace")
 				So(results, ShouldBeEmpty)
 			})
 
@@ -247,18 +366,20 @@ func TestCollectMetrics(t *testing.T) {
 			makeSleepyName := func(num int) string {
 				return fmt.Sprintf("sleepy%d", num)
 			}
-			statsRes := map[string][]Proc{}
+			statsRes := map[string]map[int]Proc{}
 			for i := 0; i < 10; i++ {
 				procName := makeSleepyName(i)
-				statsRes[procName] = []Proc{makeMockProc(procName, 24000+i)}
+				statsRes[procName] = map[int]Proc{}
+				statsRes[procName][i] = makeMockProc(procName, 24000+i)
 			}
 			numProcs := len(statsRes)
 			mc.On("GetStats").Return(statsRes, nil)
-			mockMtsWithAsterisk := []plugin.MetricType{plugin.MetricType{
-				Namespace_: core.NewNamespace("intel", "procfs", "processes").
-					AddDynamicElement("process_name", "process name").
+			mockMtsWithAsterisk := []plugin.Metric{plugin.Metric{
+				Namespace: plugin.NewNamespace("intel", "procfs", "processes", "process").
+					AddDynamicElement("process_name", "name of the process").
+					AddDynamicElement("process_pid", "identifier of the process").
 					AddStaticElement("ps_count"),
-				Config_: cfg.ConfigDataNode,
+				Config: cfg,
 			}}
 			numMts := len(mockMtsWithAsterisk)
 			Convey("and metrics for all processes are requested in call to CollectMetrics", func() {
@@ -276,7 +397,7 @@ func TestCollectMetrics(t *testing.T) {
 						expProcNames[makeSleepyName(i)] = true
 					}
 					for _, mt := range results {
-						actProcNames[mt.Namespace()[3].Value] = true
+						actProcNames[mt.Namespace[4].Value] = true
 					}
 					So(actProcNames, ShouldResemble, expProcNames)
 				})
@@ -284,10 +405,10 @@ func TestCollectMetrics(t *testing.T) {
 					expMtNames := map[string]bool{}
 					actMtNames := map[string]bool{}
 					for _, mt := range mockMtsWithAsterisk {
-						expMtNames[mt.Namespace()[4].Value] = true
+						expMtNames[mt.Namespace[6].Value] = true
 					}
 					for _, mt := range results {
-						actMtNames[mt.Namespace()[4].Value] = true
+						actMtNames[mt.Namespace[6].Value] = true
 					}
 					So(actMtNames, ShouldResemble, expMtNames)
 				})
@@ -329,9 +450,6 @@ func (mp Proc) validateValue(param string, value uint64) bool {
 	case "ps_cputime_system":
 		stime, _ := strconv.ParseUint(string(mp.Stat[14]), 10, 64)
 		refValue = stime * 10000
-	case "ps_count":
-		// single process instance is expected
-		refValue = 1
 	case "ps_vm":
 		vm, _ := strconv.ParseUint(string(mp.Stat[22]), 10, 64)
 		refValue = vm

--- a/processes/procstat_test.go
+++ b/processes/procstat_test.go
@@ -138,7 +138,7 @@ func TestGetStats(t *testing.T) {
 
 			for procName, instances := range results {
 
-				So(procName, ShouldResemble, "mockProcName")
+				So(procName, ShouldResemble, "systemd-hostnamed^@")
 
 				for _, instance := range instances {
 


### PR DESCRIPTION
Add command line metric

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #29 and #35 

Summary of changes:
- Changed namespace structure to `<process_name>/<process_pid>/<metric>`
- Process name is gathered from `cmdline` (no 15 character limit) or `status` line (15 character limit) for kernel processes (for kernel processes, cmdline is empty)
- Added `<process_name>/ps_count` metric for number of process instances
- Added `<process_name>/all/<metric>` for aggregated metrics
- Updated plugin for `snap-plugin-lib-go` support

How to verify it:
- Launch example task and check collected data

Testing done:
- Unit tests
- Manual testing
